### PR TITLE
Make InkWells consistent and follow Material spec

### DIFF
--- a/lib/navigation_rail.dart
+++ b/lib/navigation_rail.dart
@@ -4,7 +4,7 @@ const _tabletBreakpoint = 720.0;
 const _desktopBreakpoint = 1440.0;
 const _minHeight = 400.0;
 const _tabletSpacingVertical = 8.0;
-const _tabletSpacingHorizontial = 10.0;
+const _tabletSpacingHorizontal = 10.0;
 const _drawerWidth = 304.0;
 
 class NavigationRail extends StatelessWidget {
@@ -113,7 +113,7 @@ class NavigationRail extends StatelessWidget {
                           Padding(
                             padding: const EdgeInsets.symmetric(
                               vertical: _tabletSpacingVertical * 2,
-                              horizontal: _tabletSpacingHorizontial,
+                              horizontal: _tabletSpacingHorizontal,
                             ),
                             child: floatingActionButton,
                           ),
@@ -196,7 +196,7 @@ class NavigationRail extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(
           vertical: _tabletSpacingVertical,
-          horizontal:_tabletSpacingHorizontial,
+          horizontal:_tabletSpacingHorizontal,
         ),
         child: Column(
           children: <Widget>[

--- a/lib/navigation_rail.dart
+++ b/lib/navigation_rail.dart
@@ -114,12 +114,12 @@ class NavigationRail extends StatelessWidget {
                       children: <Widget>[
                         if (floatingActionButton != null)
                           Container(
-                            padding: const EdgeInsets.only(top: 8.0),
+                            padding: const EdgeInsets.only(top: _tabletSpacingVertical),
                             width: _railSize,
                             height: _railSize,
                             child: Center(child: floatingActionButton),
                           ),
-                        Container(padding: const EdgeInsets.only(top: 8.0)),
+                        Container(padding: const EdgeInsets.only(top: _tabletSpacingVertical)),
                         for (var tab in tabs)
                           _buildTab(currentIndex == tabs.indexOf(tab),
                               context, tab),

--- a/lib/navigation_rail.dart
+++ b/lib/navigation_rail.dart
@@ -6,6 +6,8 @@ const _minHeight = 400.0;
 const _tabletSpacingVertical = 8.0;
 const _tabletSpacingHorizontal = 10.0;
 const _drawerWidth = 304.0;
+const _railSize = 72.0;
+const _denseRailSize = 56.0;
 
 class NavigationRail extends StatelessWidget {
   final FloatingActionButton floatingActionButton;
@@ -107,26 +109,20 @@ class NavigationRail extends StatelessWidget {
               body: Row(
                 children: <Widget>[
                   Container(
+                    width: isDense ? _denseRailSize : _railSize,
                     child: Column(
                       children: <Widget>[
-                        if (floatingActionButton != null) ...[
-                          Padding(
-                            padding: const EdgeInsets.symmetric(
-                              vertical: _tabletSpacingVertical * 2,
-                              horizontal: _tabletSpacingHorizontal,
-                            ),
-                            child: floatingActionButton,
+                        if (floatingActionButton != null)
+                          Container(
+                            padding: const EdgeInsets.only(top: 8.0),
+                            width: _railSize,
+                            height: _railSize,
+                            child: Center(child: floatingActionButton),
                           ),
-                        ],
-                        for (var tab in tabs) ...[
-                          Padding(
-                            padding: const EdgeInsets.symmetric(
-                              vertical: _tabletSpacingVertical,
-                            ),
-                            child: _buildTab(currentIndex == tabs.indexOf(tab),
-                                context, tab),
-                          ),
-                        ],
+                        Container(padding: const EdgeInsets.only(top: 8.0)),
+                        for (var tab in tabs)
+                          _buildTab(currentIndex == tabs.indexOf(tab),
+                              context, tab),
                       ],
                     ),
                   ),
@@ -183,30 +179,40 @@ class NavigationRail extends StatelessWidget {
       ),
     );
     if (isDense) {
-      return InkWell(
-        onTap: () => onTap(tabs.indexOf(item)),
+      return Container(
+        height: _denseRailSize,
+        width: _denseRailSize,
         child: Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: _icon,
+          padding: const EdgeInsets.all(4.0),
+          child: InkWell(
+            onTap: () => onTap(tabs.indexOf(item)),
+            child: Center(
+              child: _icon,
+            ),
+          ),
         ),
       );
     }
-    return InkWell(
-      onTap: () => onTap(tabs.indexOf(item)),
+    return Container(
+      height: _railSize,
+      width: _railSize,
       child: Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: _tabletSpacingVertical,
-          horizontal:_tabletSpacingHorizontal,
-        ),
-        child: Column(
-          children: <Widget>[
-            _icon,
-            Container(height: 4.0),
-            DefaultTextStyle(
-              style: TextStyle(color: _color),
-              child: item?.title,
+        padding: const EdgeInsets.all(4.0),
+        child: InkWell(
+          onTap: () => onTap(tabs.indexOf(item)),
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                _icon,
+                Container(height: 4.0),
+                DefaultTextStyle(
+                  style: TextStyle(color: _color),
+                  child: item?.title,
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/navigation_rail.dart
+++ b/lib/navigation_rail.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 const _tabletBreakpoint = 720.0;
 const _desktopBreakpoint = 1440.0;
 const _minHeight = 400.0;
-const _tabletSpacingVertical = 15.0;
+const _tabletSpacingVertical = 8.0;
 const _tabletSpacingHorizontial = 10.0;
 const _drawerWidth = 304.0;
 
@@ -112,7 +112,7 @@ class NavigationRail extends StatelessWidget {
                         if (floatingActionButton != null) ...[
                           Padding(
                             padding: const EdgeInsets.symmetric(
-                              vertical: _tabletSpacingVertical,
+                              vertical: _tabletSpacingVertical * 2,
                               horizontal: _tabletSpacingHorizontial,
                             ),
                             child: floatingActionButton,
@@ -122,7 +122,6 @@ class NavigationRail extends StatelessWidget {
                           Padding(
                             padding: const EdgeInsets.symmetric(
                               vertical: _tabletSpacingVertical,
-                              horizontal: _tabletSpacingHorizontial,
                             ),
                             child: _buildTab(currentIndex == tabs.indexOf(tab),
                                 context, tab),
@@ -194,15 +193,21 @@ class NavigationRail extends StatelessWidget {
     }
     return InkWell(
       onTap: () => onTap(tabs.indexOf(item)),
-      child: Column(
-        children: <Widget>[
-          _icon,
-          Container(height: 4.0),
-          DefaultTextStyle(
-            style: TextStyle(color: _color),
-            child: item?.title,
-          ),
-        ],
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: _tabletSpacingVertical,
+          horizontal:_tabletSpacingHorizontial,
+        ),
+        child: Column(
+          children: <Widget>[
+            _icon,
+            Container(height: 4.0),
+            DefaultTextStyle(
+              style: TextStyle(color: _color),
+              child: item?.title,
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
I made some adjustments to the sizing and positioning of the "tablet" sized rail to more closely follow the [Material spec](https://material.io/components/navigation-rail/#specs) and to help the `InkWell`s of each rail item be a consistent size.

Also fixed a minor typo in a variable name.

Let me know what you think!

Biggest changes:

- Non-dense rail is now locked at 72.0 dp width, per spec
- Dense rail now locked at 56.0 dp width, per spec
- `InkWell`s are now a consistent size.

[Before](https://i.imgur.com/ZpQeOKC.png) & [After](https://i.imgur.com/c7EnSr0.png)