### PR TITLE
Added label property into NavigationRailDestination if title property…

### DIFF
--- a/lib/navigation_rail.dart
+++ b/lib/navigation_rail.dart
@@ -157,7 +157,7 @@ class NavRail extends StatelessWidget {
       onDestinationSelected: (val) => onTap(val),
       destinations: tabs
           .map((e) => NavigationRailDestination(
-                label: e.title,
+                label: e.title ?? Text(e.label),
                 icon: e.icon,
               ))
           .toList(),


### PR DESCRIPTION
 Cause `BottomNavigationBarItem` `title` property is deprecated since Flutter 1.19, I added `label` property into `NavigationRailDestination` mapping if `title` property is not set.